### PR TITLE
Fixed camera setters to be no longer persistent and reflect coord system

### DIFF
--- a/src/Roassal3-Exporters/RSAbstractCamSetter.class.st
+++ b/src/Roassal3-Exporters/RSAbstractCamSetter.class.st
@@ -42,6 +42,7 @@ RSAbstractCamSetter >> set: aBlock [
 	| camera |
 	self setCanvasCamera.
 	camera := canvas camera copy.
+	camera matrix: canvas camera matrix copy.
 	self shouldUseDoubleDraw 
 		ifTrue: [ canvas morph drawOnMockCanvas ].
 	self setCamera.

--- a/src/Roassal3-Exporters/RSZoomToShapesSetter.class.st
+++ b/src/Roassal3-Exporters/RSZoomToShapesSetter.class.st
@@ -18,6 +18,6 @@ RSZoomToShapesSetter >> setCamera [
 	| rect |
 	rect := canvas encompassingRectangle.
 	canvas camera
-		scale: 1;
+		privateScale: 1; "prevent announcements, similarly to position: vs translateTo:"
 		position: (canvas camera positionFromSpace: rect floatCenter)
 ]

--- a/src/Roassal3-Exporters/RSZoomToShapesSetter.class.st
+++ b/src/Roassal3-Exporters/RSZoomToShapesSetter.class.st
@@ -14,9 +14,10 @@ RSZoomToShapesSetter >> extent [
 
 { #category : #hooks }
 RSZoomToShapesSetter >> setCamera [
+
 	| rect |
-	rect := canvas encompassingRectangle. 
+	rect := canvas encompassingRectangle.
 	canvas camera
-		position: rect floatCenter;
-		scale: 1
+		scale: 1;
+		position: (canvas camera positionFromSpace: rect floatCenter)
 ]


### PR DESCRIPTION
Fixes unintentional side effects of new Roassal3 coordiante system on camera setters.
Fixes one problem caused by new coordinate system mentioned in https://github.com/ObjectProfile/Roassal3/issues/523 (at least the class comment problem still remains there)